### PR TITLE
Allow human readable rules to be passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Available targets:
 | [aws_inspector_assessment_target.target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector_assessment_target) | resource |
 | [aws_inspector_assessment_template.assessment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector_assessment_template) | resource |
 | [aws_iam_policy_document.start_assessment_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -175,10 +176,10 @@ Available targets:
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Flag to indicate whether an IAM Role should be created to grant the proper permissions for AWS Config | `bool` | `false` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| <a name="input_enabled_rules"></a> [enabled\_rules](#input\_enabled\_rules) | A list of AWS Inspector rules that should run on a periodic basis. <br><br>For a list of available rules by region, see:<br>https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html | `list(string)` | n/a | yes |
+| <a name="input_enabled_rules"></a> [enabled\_rules](#input\_enabled\_rules) | A list of AWS Inspector rules that should run on a periodic basis.<br><br>Valid values are `cve`, `cis`, `nr`, `sbp` which map to the appropriate [Inspector rule arns by region](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html). | `list(string)` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_event_rule_description"></a> [event\_rule\_description](#input\_event\_rule\_description) | A description of the CloudWatch event rule | `string` | `"Trigger an AWS Inspector Assessment"` | no |
-| <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the <br>AWS resources associated with the account. This is only used if create\_iam\_role is false.<br><br>If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set <br>create\_iam\_role to false. | `string` | `null` | no |
+| <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the<br>AWS resources associated with the account. This is only used if create\_iam\_role is false.<br><br>If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set<br>create\_iam\_role to false. | `string` | `null` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
@@ -186,7 +187,7 @@ Available targets:
 | <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | An AWS Schedule Expression to indicate how often the scheduled event shoud run. <br><br>For more information see: <br>https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html | `string` | `"rate(7 days)"` | no |
+| <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | An AWS Schedule Expression to indicate how often the scheduled event shoud run.<br><br>For more information see:<br>https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html | `string` | `"rate(7 days)"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -31,6 +31,7 @@
 | [aws_inspector_assessment_target.target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector_assessment_target) | resource |
 | [aws_inspector_assessment_template.assessment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector_assessment_template) | resource |
 | [aws_iam_policy_document.start_assessment_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -43,10 +44,10 @@
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Flag to indicate whether an IAM Role should be created to grant the proper permissions for AWS Config | `bool` | `false` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| <a name="input_enabled_rules"></a> [enabled\_rules](#input\_enabled\_rules) | A list of AWS Inspector rules that should run on a periodic basis. <br><br>For a list of available rules by region, see:<br>https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html | `list(string)` | n/a | yes |
+| <a name="input_enabled_rules"></a> [enabled\_rules](#input\_enabled\_rules) | A list of AWS Inspector rules that should run on a periodic basis.<br><br>Valid values are `cve`, `cis`, `nr`, `sbp` which map to the appropriate [Inspector rule arns by region](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html). | `list(string)` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_event_rule_description"></a> [event\_rule\_description](#input\_event\_rule\_description) | A description of the CloudWatch event rule | `string` | `"Trigger an AWS Inspector Assessment"` | no |
-| <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the <br>AWS resources associated with the account. This is only used if create\_iam\_role is false.<br><br>If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set <br>create\_iam\_role to false. | `string` | `null` | no |
+| <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the<br>AWS resources associated with the account. This is only used if create\_iam\_role is false.<br><br>If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set<br>create\_iam\_role to false. | `string` | `null` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
@@ -54,7 +55,7 @@
 | <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | An AWS Schedule Expression to indicate how often the scheduled event shoud run. <br><br>For more information see: <br>https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html | `string` | `"rate(7 days)"` | no |
+| <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | An AWS Schedule Expression to indicate how often the scheduled event shoud run.<br><br>For more information see:<br>https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html | `string` | `"rate(7 days)"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -1,6 +1,5 @@
-region          = "us-east-2"
 namespace       = "eg"
 environment     = "ue2"
 stage           = "test"
 create_iam_role = true
-enabled_rules   = ["arn:aws:inspector:us-east-2:646659390643:rulespackage/0-m8r61nnh"]
+enabled_rules   = ["cis"]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,6 +1,7 @@
 provider "aws" {
-  region = var.region
+  region = "us-east-2"
 }
+
 module "inspector" {
   source = "../.."
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,20 +1,49 @@
-variable "region" {
-  type        = string
-  description = "AWS region"
-}
-
 variable "create_iam_role" {
   description = "Flag to indicate whether an IAM Role should be created to grant the proper permissions for AWS Config"
   type        = bool
   default     = false
 }
 
+variable "iam_role_arn" {
+  description = <<-DOC
+    The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the
+    AWS resources associated with the account. This is only used if create_iam_role is false.
+
+    If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set
+    create_iam_role to false.
+  DOC
+  default     = null
+  type        = string
+}
+
+variable "assessment_duration" {
+  type        = string
+  description = "The max duration of the Inspector assessment run in seconds"
+  default     = "3600" # 1 hour
+}
+
+variable "schedule_expression" {
+  type        = string
+  description = <<-DOC
+    An AWS Schedule Expression to indicate how often the scheduled event shoud run.
+
+    For more information see:
+    https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+  DOC
+  default     = "rate(7 days)"
+}
+
+variable "event_rule_description" {
+  type        = string
+  description = "A description of the CloudWatch event rule"
+  default     = "Trigger an AWS Inspector Assessment"
+}
+
 variable "enabled_rules" {
   type        = list(string)
   description = <<-DOC
-    A list of AWS Inspector rules that should run on a periodic basis. 
-    
-    For a list of available rules by region, see:
-    https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html
+    A list of AWS Inspector rules that should run on a periodic basis.
+
+    Valid values are `cve`, `cis`, `nr`, `sbp` which map to the appropriate [Inspector rule arns by region](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html).
   DOC
 }

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "aws_inspector_assessment_template" "assessment" {
   name               = module.inspector_assessment_template_label.id
   target_arn         = aws_inspector_assessment_target.target[0].arn
   duration           = var.assessment_duration
-  rules_package_arns = var.enabled_rules
+  rules_package_arns = local.rules_package_arns
 }
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -93,10 +93,96 @@ data "aws_iam_policy_document" "start_assessment_policy" {
   }
 }
 
+data "aws_region" "current" {}
+
 #-----------------------------------------------------------------------------------------------------------------------
 # Locals and Data References
 #-----------------------------------------------------------------------------------------------------------------------
 locals {
   create          = module.this.enabled && length(var.enabled_rules) > 0
   create_iam_role = local.create && var.create_iam_role
+
+  # Rules created from https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html
+  inspector_rules = {
+    cve = {
+      name = "Common Vulnerabilities and Exposures",
+      arn = {
+        "us-east-2"      = "arn:aws:inspector:us-east-2:646659390643:rulespackage/0-JnA8Zp85"
+        "us-east-1"      = "arn:aws:inspector:us-east-1:316112463485:rulespackage/0-gEjTy7T7"
+        "us-west-1"      = "arn:aws:inspector:us-west-1:166987590008:rulespackage/0-TKgzoVOa"
+        "us-west-2"      = "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-9hgA516p",
+        "ap-south-1"     = "arn:aws:inspector:ap-south-1:162588757376:rulespackage/0-LqnJE9dO"
+        "ap-northeast-2" = "arn:aws:inspector:ap-northeast-2:526946625049:rulespackage/0-PoGHMznc"
+        "ap-southeast-2" = "arn:aws:inspector:ap-southeast-2:454640832652:rulespackage/0-D5TGAxiR"
+        "ap-northeast-1" = "arn:aws:inspector:ap-northeast-1:406045910587:rulespackage/0-gHP9oWNT"
+        "eu-central-1"   = "arn:aws:inspector:eu-central-1:537503971621:rulespackage/0-wNqHa8M9"
+        "eu-west-1"      = "arn:aws:inspector:eu-west-1:357557129151:rulespackage/0-ubA5XvBh"
+        "eu-west-2"      = "arn:aws:inspector:eu-west-2:146838936955:rulespackage/0-kZGCqcE1"
+        "eu-north-1"     = "arn:aws:inspector:eu-north-1:453420244670:rulespackage/0-IgdgIewd"
+        "us-gov-east-1"  = "arn:aws-us-gov:inspector:us-gov-east-1:206278770380:rulespackage/0-3IFKFuOb"
+        "us-gov-west-1"  = "arn:aws-us-gov:inspector:us-gov-west-1:850862329162:rulespackage/0-4oQgcI4G"
+      }
+    },
+    cis = {
+      name = "CIS Operating System Security Configuration Benchmarks",
+      arn = {
+        "us-east-2"      = "arn:aws:inspector:us-east-2:646659390643:rulespackage/0-m8r61nnh"
+        "us-east-1"      = "arn:aws:inspector:us-east-1:316112463485:rulespackage/0-rExsr2X8"
+        "us-west-1"      = "arn:aws:inspector:us-west-1:166987590008:rulespackage/0-xUY8iRqX"
+        "us-west-2"      = "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-H5hpSawc"
+        "ap-south-1"     = "arn:aws:inspector:ap-south-1:162588757376:rulespackage/0-PSUlX14m"
+        "ap-northeast-2" = "arn:aws:inspector:ap-northeast-2:526946625049:rulespackage/0-T9srhg1z"
+        "ap-southeast-2" = "arn:aws:inspector:ap-southeast-2:454640832652:rulespackage/0-Vkd2Vxjq"
+        "ap-northeast-1" = "arn:aws:inspector:ap-northeast-1:406045910587:rulespackage/0-7WNjqgGu"
+        "eu-central-1"   = "arn:aws:inspector:eu-central-1:537503971621:rulespackage/0-nZrAVuv8"
+        "eu-west-1"      = "arn:aws:inspector:eu-west-1:357557129151:rulespackage/0-sJBhCr0F"
+        "eu-west-2"      = "arn:aws:inspector:eu-west-2:146838936955:rulespackage/0-IeCjwf1W"
+        "eu-north-1"     = "arn:aws:inspector:eu-north-1:453420244670:rulespackage/0-Yn8jlX7f"
+        "us-gov-east-1"  = "arn:aws-us-gov:inspector:us-gov-east-1:206278770380:rulespackage/0-pTLCdIww"
+        "us-gov-west-1"  = "arn:aws-us-gov:inspector:us-gov-west-1:850862329162:rulespackage/0-Ac4CFOuc"
+      }
+    },
+    nr = {
+      name = "Network Reachability",
+      arn = {
+        "us-east-2"      = "arn:aws:inspector:us-east-2:646659390643:rulespackage/0-cE4kTR30"
+        "us-east-1"      = "arn:aws:inspector:us-east-1:316112463485:rulespackage/0-PmNV0Tcd"
+        "us-west-1"      = "arn:aws:inspector:us-west-1:166987590008:rulespackage/0-TxmXimXF"
+        "us-west-2"      = "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-rD1z6dpl"
+        "ap-south-1"     = "arn:aws:inspector:ap-south-1:162588757376:rulespackage/0-YxKfjFu1"
+        "ap-northeast-2" = "arn:aws:inspector:ap-northeast-2:526946625049:rulespackage/0-s3OmLzhL"
+        "ap-southeast-2" = "arn:aws:inspector:ap-southeast-2:454640832652:rulespackage/0-FLcuV4Gz"
+        "ap-northeast-1" = "arn:aws:inspector:ap-northeast-1:406045910587:rulespackage/0-YI95DVd7"
+        "eu-central-1"   = "arn:aws:inspector:eu-central-1:537503971621:rulespackage/0-6yunpJ91"
+        "eu-west-1"      = "arn:aws:inspector:eu-west-1:357557129151:rulespackage/0-SPzU33xe"
+        "eu-west-2"      = "arn:aws:inspector:eu-west-2:146838936955:rulespackage/0-AizSYyNq"
+        "eu-north-1"     = "arn:aws:inspector:eu-north-1:453420244670:rulespackage/0-52Sn74uu"
+        "us-gov-east-1"  = null
+        "us-gov-west-1"  = null
+      }
+    },
+    sbp = {
+      name = "Security Best Practices",
+      arn = {
+        "us-east-2"      = "arn:aws:inspector:us-east-2:646659390643:rulespackage/0-AxKmMHPX"
+        "us-east-1"      = "arn:aws:inspector:us-east-1:316112463485:rulespackage/0-R01qwB5Q"
+        "us-west-1"      = "arn:aws:inspector:us-west-1:166987590008:rulespackage/0-byoQRFYm"
+        "us-west-2"      = "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-JJOtZiqQ"
+        "ap-south-1"     = "arn:aws:inspector:ap-south-1:162588757376:rulespackage/0-fs0IZZBj"
+        "ap-northeast-2" = "arn:aws:inspector:ap-northeast-2:526946625049:rulespackage/0-2WRpmi4n"
+        "ap-southeast-2" = "arn:aws:inspector:ap-southeast-2:454640832652:rulespackage/0-asL6HRgN"
+        "ap-northeast-1" = "arn:aws:inspector:ap-northeast-1:406045910587:rulespackage/0-bBUQnxMq"
+        "eu-central-1"   = "arn:aws:inspector:eu-central-1:537503971621:rulespackage/0-ZujVHEPB"
+        "eu-west-1"      = "arn:aws:inspector:eu-west-1:357557129151:rulespackage/0-SnojL3Z6"
+        "eu-west-2"      = "arn:aws:inspector:eu-west-2:146838936955:rulespackage/0-XApUiSaP"
+        "eu-north-1"     = "arn:aws:inspector:eu-north-1:453420244670:rulespackage/0-HfBQSbSf"
+        "us-gov-east-1"  = "arn:aws-us-gov:inspector:us-gov-east-1:206278770380:rulespackage/0-vlgEGcVD"
+        "us-gov-west-1"  = "arn:aws-us-gov:inspector:us-gov-west-1:850862329162:rulespackage/0-rOTGqe5G"
+      }
+    },
+  }
+  rules_package_arns = [
+    for rule in var.enabled_rules :
+    local.inspector_rules[rule]["arn"][data.aws_region.current.name]
+  ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,10 +6,10 @@ variable "create_iam_role" {
 
 variable "iam_role_arn" {
   description = <<-DOC
-    The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the 
+    The ARN for an IAM Role AWS Config uses to make read or write requests to the delivery channel and to describe the
     AWS resources associated with the account. This is only used if create_iam_role is false.
-  
-    If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set 
+
+    If you want to use an existing IAM Role, set the value of this to the ARN of the existing topic and set
     create_iam_role to false.
   DOC
   default     = null
@@ -25,9 +25,9 @@ variable "assessment_duration" {
 variable "schedule_expression" {
   type        = string
   description = <<-DOC
-    An AWS Schedule Expression to indicate how often the scheduled event shoud run. 
-  
-    For more information see: 
+    An AWS Schedule Expression to indicate how often the scheduled event shoud run.
+
+    For more information see:
     https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
   DOC
   default     = "rate(7 days)"
@@ -42,9 +42,8 @@ variable "event_rule_description" {
 variable "enabled_rules" {
   type        = list(string)
   description = <<-DOC
-    A list of AWS Inspector rules that should run on a periodic basis. 
-    
-    For a list of available rules by region, see:
-    https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html
+    A list of AWS Inspector rules that should run on a periodic basis.
+
+    Valid values are `cve`, `cis`, `nr`, `sbp` which map to the appropriate [Inspector rule arns by region](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html).
   DOC
 }


### PR DESCRIPTION
## what
* Create a mapping of https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html
* Allow human readable rules to be passed in like `cis`

## why
* This simplifies figuring out the correct arns of the rules that we want applied

## references
N/A

